### PR TITLE
Add CI pipeline and test the example repo. Fix bugs found as a result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
 before_script:
 - yarn
 - yarn list
-script: ci-test.sh
+script: bash ./ci-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+os: linux
+node_js: lts/*
+cache:
+  yarn: true
+before_script:
+- yarn
+- yarn list
+script: ci-test.sh

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -1,0 +1,14 @@
+echo 'gday trav'
+yarn link
+rm -rf tmp
+mkdir tmp && cd tmp
+git clone https://github.com/cultureamp/cultureamp-front-end-example.git
+cd cultureamp-front-end-example
+yarn
+yarn link cultureamp-front-end-scripts
+yarn flow
+yarn lint
+yarn test
+yarn format
+echo 'cheers trav'
+

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -1,4 +1,11 @@
-echo 'gday trav'
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+echo "👋 G'day Trav"
+
+# Clone the example repo, install dependencies and link scripts
 yarn link
 rm -rf tmp
 mkdir tmp && cd tmp
@@ -6,9 +13,12 @@ git clone https://github.com/cultureamp/cultureamp-front-end-example.git
 cd cultureamp-front-end-example
 yarn
 yarn link cultureamp-front-end-scripts
+
+# Run the tests
 yarn flow
 yarn lint
 yarn test
 yarn format
-echo 'cheers trav'
+
+echo "Cheers Trav 👋"
 

--- a/config/jest/babel/preprocessor.js
+++ b/config/jest/babel/preprocessor.js
@@ -28,10 +28,15 @@ module.exports = {
     if (shouldBabelPreprocess(filename)) {
       var babelOpts = {
         ...babelConfig,
-        presets: [].concat(
-          babelConfig.presets,
-          jestPreset // hoist jest api calls above imports
-        ),
+        presets: [
+          ...babelConfig.presets,
+          jestPreset,
+          ["env", {
+            "targets": {
+              "node": "current"
+            }
+          }]
+        ],
         filename: filename,
         sourceMap: true,
         auxiliaryCommentBefore: ' istanbul ignore next ',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react": "^7.7.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "flow-bin": "^0.66.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^22.4.2",
     "lodash.isequal": "^4.5.0",
     "node-sass": "^4.7.2",

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
-yarn eslint --fix .
+CONFIG_FILE="$PWD/eslint.config.js"
+IGNORE_FILE="$PWD/.eslintignore"
+
+if [ ! -f $CONFIG_FILE ]
+  then
+    CONFIG_FILE="node_modules/cultureamp-front-end-scripts/config/eslint/eslint.config.js"
+fi
+
+if [ ! -f $IGNORE_FILE ]
+  then
+    echo "🖖 Local .eslintignore doesn't exist; copying from cultureamp-front-end-scripts module..."
+    cp node_modules/cultureamp-front-end-scripts/config/eslint/eslintignore $PWD/.eslintignore
+fi
+
+yarn eslint --fix --config $CONFIG_FILE --ignore-path $IGNORE_FILE .
 
 yarn prettier --write "**/*.{css,scss}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3601,6 +3601,10 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.0.tgz#9c28a77386ec225f7b5d370f9861ba09c4eea58f"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -3849,6 +3853,12 @@ icss-utils@^2.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-2.1.0.tgz#83f0a0ec378bf3246178b6c2ad9136f135b1c962"
   dependencies:
     postcss "^6.0.1"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.4:
   version "1.1.8"


### PR DESCRIPTION
Bugs fixed:

- Jest needs the "env" preset to target NodeJS
- `format.sh` command needs to load the eslint config in the same way as `lint.sh`
- identity-obj-proxy dependency was missing