### PR TITLE
Enable ESLint configuration to run in Visual Studio Code (NodeJS 7.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: cultureamp-style-front-end-scripts
 
+## 0.2.3
+
+* 👍 Enable ESLint configuration to run in Visual Studio Code (NodeJS 7.x).
+
 ## 0.2.2
 
 * 👍 Enable [historyApiFallback](https://webpack.js.org/configuration/dev-server/#devserver-historyapifallback) for webpack dev server to enable client-side routing, where the server serves index.html for all URLs.

--- a/config/webpack/presets/babel.js
+++ b/config/webpack/presets/babel.js
@@ -13,10 +13,13 @@ const babelPreset = (wcm /*: WebpackConfigMaker */) => {
     require.resolve('../../babel/babel.config.js')
   );
 
-  const babelOptions = {
-    plugins: [],
-    ...importedConfig,
-  };
+  // Avoid object spread for VSCode ESLint integration: https://github.com/Microsoft/vscode-eslint/issues/464
+  const babelOptions = Object.assign(
+    {
+      plugins: [],
+    },
+    importedConfig
+  );
 
   if (wcm.isCachingEnabled()) {
     babelOptions.cacheDirectory = wcm.getCacheDirectory();

--- a/config/webpack/presets/ca-style-guide.js
+++ b/config/webpack/presets/ca-style-guide.js
@@ -14,10 +14,13 @@ function babelPreset(wcm /*: WebpackConfigMaker */) {
   const customConfigPath = path.resolve(pwd, 'babel.config.js');
   const importedConfig = require('../../babel/babel.config.js');
 
-  const babelOptions = {
-    plugins: [],
-    ...importedConfig,
-  };
+  // Avoid object spread for VSCode ESLint integration: https://github.com/Microsoft/vscode-eslint/issues/464
+  const babelOptions = Object.assign(
+    {
+      plugins: [],
+    },
+    importedConfig
+  );
 
   if (wcm.isCachingEnabled()) {
     babelOptions.cacheDirectory = wcm.getCacheDirectory();

--- a/config/webpack/presets/static-assets.js
+++ b/config/webpack/presets/static-assets.js
@@ -3,7 +3,7 @@
 const WebpackConfigMaker = require('../../../webpack-config-maker/');
 
 const staticAssetsPreset = (wcm /*: WebpackConfigMaker */) => {
-  const fileLoaderOptions = {
+  const fileLoaderOptions /*: { name: string, limit?: number }*/ = {
     // TODO: investigate why murmur specifies a `context: 'app/assets` property here.
     name: wcm.getFilenameTemplate(),
   };
@@ -19,10 +19,10 @@ const staticAssetsPreset = (wcm /*: WebpackConfigMaker */) => {
   });
 
   wcm.registerLoader('url-loader', {
-    options: {
-      ...fileLoaderOptions,
+    // Avoid object spread for VSCode ESLint integration: https://github.com/Microsoft/vscode-eslint/issues/464
+    options: Object.assign(fileLoaderOptions, {
       limit: 10000, // Only apply to files below this size (in bytes)
-    },
+    }),
   });
 
   wcm.addRule({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-front-end-scripts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "index.js",
   "repository": "https://github.com/cultureamp/cultureamp-front-end-scripts.git",
   "author": "FECT",

--- a/webpack-config-maker/webpackConfigMaker.js
+++ b/webpack-config-maker/webpackConfigMaker.js
@@ -98,10 +98,7 @@ class WebpackConfigMaker {
   }
 
   getProjectDirectory() {
-    if (!process.env.PWD) {
-      throw 'The environment variable $PWD was not set';
-    }
-    return process.env.PWD;
+    return process.cwd();
   }
 
   getCacheDirectory() {

--- a/webpack-config-maker/webpackConfigMaker.test.js
+++ b/webpack-config-maker/webpackConfigMaker.test.js
@@ -1,15 +1,13 @@
 const WebpackConfigMaker = require('./webpackConfigMaker');
 
-let pwd;
+let cwd;
 
 beforeEach(() => {
-  pwd = process.env.PWD;
-  process.env.PWD = '/user/workspace';
+  cwd = process.cwd();
   process.env.NODE_ENV = 'development';
 });
 
 afterEach(() => {
-  process.env.PWD = pwd;
   process.env.NODE_ENV = 'development';
 });
 
@@ -45,8 +43,8 @@ describe('our webpack config thing', () => {
 
       const config = wcm.generateWebpackConfig();
       expect(config.resolve.modules).toEqual([
-        '/user/workspace/node_modules',
-        '/user/workspace/src',
+        `${cwd}/node_modules`,
+        `${cwd}/src`,
       ]);
     });
 
@@ -56,9 +54,9 @@ describe('our webpack config thing', () => {
 
       const config = wcm.generateWebpackConfig();
       expect(config.resolve.modules).toEqual([
-        '/user/workspace/node_modules',
-        '/user/workspace/app/client/modules',
-        '/user/workspace/lib/client/modules',
+        `${cwd}/node_modules`,
+        `${cwd}/app/client/modules`,
+        `${cwd}/lib/client/modules`,
       ]);
     });
 
@@ -68,8 +66,8 @@ describe('our webpack config thing', () => {
 
       const config = wcm.generateWebpackConfig();
       expect(config.resolve.modules).toEqual([
-        '/user/workspace/node_modules',
-        '/user/workspace/app/client/modules',
+        `${cwd}/node_modules`,
+        `${cwd}/app/client/modules`,
       ]);
     });
   });
@@ -78,7 +76,7 @@ describe('our webpack config thing', () => {
     test('has a default of public/', () => {
       const wcm = new WebpackConfigMaker();
       const config = wcm.generateWebpackConfig();
-      expect(config.output.path).toEqual('/user/workspace/public/assets/');
+      expect(config.output.path).toEqual(`${cwd}/public/assets/`);
     });
 
     test('allows changing the web root', () => {
@@ -86,7 +84,7 @@ describe('our webpack config thing', () => {
       wcm.setWebRoot('www');
 
       const config = wcm.generateWebpackConfig();
-      expect(config.output.path).toEqual('/user/workspace/www/assets/');
+      expect(config.output.path).toEqual(`${cwd}/www/assets/`);
     });
   });
 
@@ -96,7 +94,7 @@ describe('our webpack config thing', () => {
 
       const config = wcm.generateWebpackConfig();
       expect(config.output.publicPath).toEqual('/assets/');
-      expect(config.output.path).toEqual('/user/workspace/public/assets/');
+      expect(config.output.path).toEqual(`${cwd}/public/assets/`);
     });
 
     test('allows changing the asset path', () => {
@@ -104,7 +102,7 @@ describe('our webpack config thing', () => {
       wcm.setAssetPathRelativeToWebRoot('/js/');
 
       const config = wcm.generateWebpackConfig();
-      expect(config.output.path).toEqual('/user/workspace/public/js/');
+      expect(config.output.path).toEqual(`${cwd}/public/js/`);
       expect(config.output.publicPath).toEqual('/js/');
     });
 
@@ -113,7 +111,7 @@ describe('our webpack config thing', () => {
       wcm.setAssetPathRelativeToWebRoot('js');
 
       const config = wcm.generateWebpackConfig();
-      expect(config.output.path).toEqual('/user/workspace/public/js/');
+      expect(config.output.path).toEqual(`${cwd}/public/js/`);
       expect(config.output.publicPath).toEqual('/js/');
     });
   });
@@ -362,7 +360,7 @@ describe('our webpack config thing', () => {
         expect(config.module.rules).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              include: ['/user/workspace/src'],
+              include: [`${cwd}/src`],
             }),
           ])
         );
@@ -381,10 +379,7 @@ describe('our webpack config thing', () => {
         expect(config.module.rules).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              include: [
-                '/user/workspace/src/components',
-                '/user/workspace/src/stuff',
-              ],
+              include: [`${cwd}/src/components`, `${cwd}/src/stuff`],
             }),
           ])
         );
@@ -404,7 +399,7 @@ describe('our webpack config thing', () => {
         expect(wcm.rules).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              exclude: ['/user/workspace/src/assets'],
+              exclude: [`${cwd}/src/assets`],
             }),
           ])
         );
@@ -422,10 +417,7 @@ describe('our webpack config thing', () => {
         expect(wcm.rules).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              exclude: [
-                '/user/workspace/src/assets',
-                '/user/workspace/src/utils',
-              ],
+              exclude: [`${cwd}/src/assets`, `${cwd}/src/utils`],
             }),
           ])
         );
@@ -563,13 +555,13 @@ describe('our webpack config thing', () => {
         });
 
         test('the includes are output correctly', () => {
-          expect(cssRule.include).toEqual(['/user/workspace/src/styles']);
-          expect(jsRule.include).toEqual(['/user/workspace/src']);
+          expect(cssRule.include).toEqual([`${cwd}/src/styles`]);
+          expect(jsRule.include).toEqual([`${cwd}/src`]);
         });
 
         test('the excludes are output correctly', () => {
           expect(cssRule.exclude).toBe(undefined);
-          expect(jsRule.exclude).toEqual(['/user/workspace/src/vendor']);
+          expect(jsRule.exclude).toEqual([`${cwd}/src/vendor`]);
         });
 
         test('the loader config is output correctly', () => {
@@ -764,8 +756,8 @@ describe('our webpack config thing', () => {
       const wcm = new WebpackConfigMaker();
       wcm.usePreset('./__fixtures__/examplePreset.js');
       expect(wcm.sourceDirectories).toEqual([
-        '/user/workspace/app/client/modules',
-        '/user/workspace/lib/client/modules',
+        `${cwd}/app/client/modules`,
+        `${cwd}/lib/client/modules`,
       ]);
     });
 
@@ -787,11 +779,11 @@ describe('our webpack config thing', () => {
         },
         './__fixtures__/examplePreset.js',
       ]);
-      expect(wcm.webRootPath).toEqual('/user/workspace/bin');
+      expect(wcm.webRootPath).toEqual(`${cwd}/bin`);
       expect(wcm.entryPoints).toEqual(['src/app.js']);
       expect(wcm.sourceDirectories).toEqual([
-        '/user/workspace/app/client/modules',
-        '/user/workspace/lib/client/modules',
+        `${cwd}/app/client/modules`,
+        `${cwd}/lib/client/modules`,
       ]);
     });
   });
@@ -835,23 +827,22 @@ describe('our webpack config thing', () => {
 
     test('getProjectDirectory() returns the current PWD', () => {
       const wcm = new WebpackConfigMaker();
-      expect(wcm.getProjectDirectory()).toBe('/user/workspace');
+      expect(wcm.getProjectDirectory()).toBe(`${cwd}`);
     });
 
     test('getCacheDirectory() returns $PWD/tmp/cache by default', () => {
       const wcm = new WebpackConfigMaker();
-      expect(wcm.getCacheDirectory()).toBe('/user/workspace/tmp/cache');
+      expect(wcm.getCacheDirectory()).toBe(`${cwd}/tmp/cache`);
     });
 
     test('isDevServer() is true when using webpack-dev-server', () => {
-      require.main.filename =
-        '/user/workspace/node_modules/.bin/webpack-dev-server.js';
+      require.main.filename = `${cwd}/node_modules/.bin/webpack-dev-server.js`;
       const wcm = new WebpackConfigMaker();
       expect(wcm.isDevServer()).toBeTruthy();
     });
 
     test('isDevServer() is false when using normal webpack', () => {
-      require.main.filename = '/user/workspace/node_modules/.bin/webpack.js';
+      require.main.filename = `${cwd}/node_modules/.bin/webpack.js`;
       const wcm = new WebpackConfigMaker();
       expect(wcm.isDevServer()).toBeFalsy();
     });


### PR DESCRIPTION
VSCode currently runs ESLint with an embedded NodeJS 7.x, which does not support object spread syntax. See Microsoft/vscode-eslint#464. We must therefore avoid object spread in our webpack configuration (which our ESLint config depends upon).

VSCode changes the process directory before running ESLint, which is reflected in `process.cwd()` but not in `process.env.PWD`. We must therefore use the former in order for VSCode to be able to resolve relative paths correctly in ESLint config.