### PR TITLE
Use process.cwd() to load webpack config in ESLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: cultureamp-style-front-end-scripts
 
+## 0.2.4
+
+* 🐛 Fix path issue with ESLint configuration in Visual Studio Code.
+
 ## 0.2.3
 
 * 👍 Enable ESLint configuration to run in Visual Studio Code (NodeJS 7.x).

--- a/config/eslint/eslint.config.js
+++ b/config/eslint/eslint.config.js
@@ -8,7 +8,7 @@ module.exports = {
     'import/resolver': {
       webpack: {
         config:
-          process.env.PWD +
+          process.cwd() +
           '/node_modules/cultureamp-front-end-scripts/config/webpack/webpack.config.js',
       },
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-front-end-scripts",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "index.js",
   "repository": "https://github.com/cultureamp/cultureamp-front-end-scripts.git",
   "author": "FECT",


### PR DESCRIPTION
VSCode changes the directory after starting the process, so process.env.PWD is not the correct directory in that environment.