### PR TITLE
Upgrade flow to 0.73.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
     "expose-loader": "^0.7.5",
-    "flow-bin": "^0.69.0",
+    "flow-bin": "^0.73.0",
     "html-webpack-harddisk-plugin": "^0.2.0",
     "html-webpack-plugin": "^3.2.0",
     "identity-obj-proxy": "^3.0.0",

--- a/webpack-config-maker/webpackConfigMaker.js
+++ b/webpack-config-maker/webpackConfigMaker.js
@@ -250,11 +250,14 @@ class WebpackConfigMaker {
   }
 
   _generateRule(rule /* :ProcessedRuleOpts */) {
+    const loaders /* :?Array<LoaderOpts | String> */ = rule.loaders.map(
+      loader => this.loaders[loader]
+    );
     const output = {
       include: rule.include || this.sourceDirectories,
       exclude: rule.exclude,
       test: new RegExp(`\\.(${rule.extensions.join('|')})$`),
-      use: rule.loaders.map(loader => this.loaders[loader]),
+      use: loaders,
       oneOf: undefined,
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3364,9 +3364,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.69.0:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.69.0.tgz#053159a684a6051fcbf0b71a2eb19a9679082da6"
+flow-bin@^0.73.0:
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
 
 flow-parser@^0.*:
   version "0.66.0"


### PR DESCRIPTION
Newer flow version provides bug fixes and also has updated flow definitions for new features in React 16.3.1 (currently the version for this project) e.g. `React.Fragment`.

There is also a small typing update as flow expects return types from array methods to be typed.
https://github.com/facebook/flow/issues/6151