### PR TITLE
Run semantic-release as a script step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 before_script:
 - yarn
 - yarn list
-script: bash ./ci-test.sh
-after_success:
-- yarn global add travis-deploy-once
-- travis-deploy-once "yarn semantic-release"
+script:
+- bash ./ci-test.sh
+- yarn semantic-release


### PR DESCRIPTION
This means the build will fail if semantic release fails. It also avoids travis-deploy-once which is likely to be deprecated.

Semantic release is smart enough to know now to deploy unless it's a master build.